### PR TITLE
Fix typo with `var.resource_group_creation_enabled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Default:
 }
 ```
 
-### <a name="input_resoruce_group_creation_enabled"></a> [resoruce\_group\_creation\_enabled](#input\_resoruce\_group\_creation\_enabled)
+### <a name="input_resource_group_creation_enabled"></a> [resource\_group\_creation\_enabled](#input\_resource\_group\_creation\_enabled)
 
 Description: This variable controls whether or not the resource group should be created. If set to false, the resource group must be created elsewhere and the resource group name must be provided to the module. If set to true, the resource group will be created by the module using the name provided in `resource_group_name`.
 

--- a/examples/with-vnet-link-existing-rg/README.md
+++ b/examples/with-vnet-link-existing-rg/README.md
@@ -70,7 +70,7 @@ module "test" {
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
 
-  resoruce_group_creation_enabled = false
+  resource_group_creation_enabled = false
 
   virtual_network_resource_ids_to_link_to = {
     "vnet1" = {

--- a/examples/with-vnet-link-existing-rg/main.tf
+++ b/examples/with-vnet-link-existing-rg/main.tf
@@ -62,7 +62,7 @@ module "test" {
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
 
-  resoruce_group_creation_enabled = false
+  resource_group_creation_enabled = false
 
   virtual_network_resource_ids_to_link_to = {
     "vnet1" = {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "this" {
-  count = var.resoruce_group_creation_enabled ? 1 : 0
+  count = var.resource_group_creation_enabled ? 1 : 0
 
   location = var.location
   name     = var.resource_group_name
@@ -7,7 +7,7 @@ resource "azurerm_resource_group" "this" {
 }
 
 data "azurerm_resource_group" "this" {
-  count = var.resoruce_group_creation_enabled ? 0 : 1
+  count = var.resource_group_creation_enabled ? 0 : 1
 
   name = var.resource_group_name
 }
@@ -18,7 +18,7 @@ module "avm_res_network_privatednszone" {
   source  = "Azure/avm-res-network-privatednszone/azurerm"
   version = "0.1.2"
 
-  resource_group_name = var.resoruce_group_creation_enabled ? azurerm_resource_group.this[0].name : var.resource_group_name
+  resource_group_name = var.resource_group_creation_enabled ? azurerm_resource_group.this[0].name : var.resource_group_name
   domain_name         = each.value.zone_value.zone_name
 
   virtual_network_links = each.value.has_vnet ? { for vnet in each.value.vnets : vnet.vnet_key => {
@@ -39,7 +39,7 @@ resource "azurerm_management_lock" "this" {
 
   lock_level = var.lock.kind
   name       = coalesce(var.lock.name, "lock-${var.lock.kind}")
-  scope      = var.resoruce_group_creation_enabled ? azurerm_resource_group.this[0].id : data.azurerm_resource_group.this[0].id
+  scope      = var.resource_group_creation_enabled ? azurerm_resource_group.this[0].id : data.azurerm_resource_group.this[0].id
   notes      = var.lock.kind == "CanNotDelete" ? "Cannot delete the resource or its child resources." : "Cannot delete or modify the resource or its child resources."
 }
 
@@ -47,7 +47,7 @@ resource "azurerm_role_assignment" "this" {
   for_each = var.resource_group_role_assignments
 
   principal_id                           = each.value.principal_id
-  scope                                  = var.resoruce_group_creation_enabled ? azurerm_resource_group.this[0].id : data.azurerm_resource_group.this[0].id
+  scope                                  = var.resource_group_creation_enabled ? azurerm_resource_group.this[0].id : data.azurerm_resource_group.this[0].id
   condition                              = each.value.condition
   condition_version                      = each.value.condition_version
   delegated_managed_identity_resource_id = each.value.delegated_managed_identity_resource_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,5 +5,5 @@ output "combined_private_link_private_dns_zones_replaced_with_vnets_to_link" {
 
 output "resource_group_resource_id" {
   description = "The resource ID of the resource group that the Private DNS Zones are deployed into."
-  value       = var.resoruce_group_creation_enabled ? azurerm_resource_group.this[0].id : data.azurerm_resource_group.this[0].id
+  value       = var.resource_group_creation_enabled ? azurerm_resource_group.this[0].id : data.azurerm_resource_group.this[0].id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -298,7 +298,7 @@ DESCRIPTION
   nullable    = false
 }
 
-variable "resoruce_group_creation_enabled" {
+variable "resource_group_creation_enabled" {
   type        = bool
   default     = true
   description = "This variable controls whether or not the resource group should be created. If set to false, the resource group must be created elsewhere and the resource group name must be provided to the module. If set to true, the resource group will be created by the module using the name provided in `resource_group_name`."


### PR DESCRIPTION
## Description

This pull request addresses a typo in the variable name `resoruce_group_creation_enabled` by correcting it to `resource_group_creation_enabled` across multiple files. This change ensures consistency and prevents potential issues related to the misspelled variable.

closes #32

Key changes include:

*Documentation Updates*:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L364-R364): Corrected the typo in the variable name from `resoruce_group_creation_enabled` to `resource_group_creation_enabled`.

*Example Configuration Updates*:
* [`examples/with-vnet-link-existing-rg/README.md`](diffhunk://#diff-bcd15b7a48ddbe13787562d72c16e9d9201098d679914e8ea98cdbf279c11313L73-R73): Updated the example configuration to use the corrected variable name.
* [`examples/with-vnet-link-existing-rg/main.tf`](diffhunk://#diff-fa8fd6c114f7d462cf534a9774fce1b6b3e647df8aae6468c34f55e89eac232cL65-R65): Updated the example configuration to use the corrected variable name.

*Main Configuration Updates*:
* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL2-R10): Corrected the variable name in multiple instances to ensure the correct variable is referenced throughout the main configuration. [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL2-R10) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL21-R21) [[3]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL42-R50)
* [`outputs.tf`](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7L8-R8): Updated the output to reference the corrected variable name.
* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL301-R301): Corrected the variable definition to ensure the correct variable name is used.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
