### PR TITLE
Remove powerbi zones from default list

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -100,15 +100,6 @@ variable "private_link_private_dns_zones" {
     azure_file_sync = {
       zone_name = "privatelink.afs.azure.net"
     }
-    azure_power_bi_tenant_analysis = {
-      zone_name = "privatelink.analysis.windows.net"
-    }
-    azure_power_bi_dedicated = {
-      zone_name = "privatelink.pbidedicated.windows.net"
-    }
-    azure_power_bi_power_query = {
-      zone_name = "privatelink.tip1.powerquery.microsoft.com"
-    }
     azure_databricks_ui_api = {
       zone_name = "privatelink.azuredatabricks.net"
     }
@@ -299,6 +290,9 @@ The folowing Private Link Private DNS Zones have been removed from the default v
 We have also removed the following Private Link Private DNS Zones from the default value for this variable as they should only be created and used with in specific scenarios:
 
 - `privatelink.azure.com`
+- `privatelink.analysis.windows.net`
+- `privatelink.pbidedicated.windows.net`
+- `privatelink.tip1.powerquery.microsoft.com`
 
 DESCRIPTION
   nullable    = false


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

See https://github.com/Azure/Enterprise-Scale/issues/1441

another similar-ish one https://github.com/Azure/Enterprise-Scale/issues/1017

Hi 👋 

It would be good if you would consider taking this change.

Power BI on Azure is broken if you enable these private endpoints and aren't able to configure it fully privately.
It was also hard to debug and understand why it was broken.

I _expect_ there's limited usage of Power BI in this scenario.

Given that it fully breaks Power BI it would be better if this was opt-in

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
