### PR TITLE
Allow excluding zones without overriding all zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Default: `null`
 
 ### <a name="input_private_link_excluded_zones"></a> [private\_link\_excluded\_zones](#input\_private\_link\_excluded\_zones)
 
-Description: A list of Private Link Private DNS Zones to exclude. The DNS zone names must match what is provided as the default values or any input to the private\_link\_private\_dns\_zones parameter e.g. privatelink.api.azureml.ms or privatelink.{regionCode}.backup.windowsazure.com or privatelink.{regionName}.azmk8s.io.
+Description: A list of Private Link Private DNS Zones to exclude. Either DNS zone names or the `private_link_private_dns_zones` map key name (e.g. 'azure\_ml') must match what is provided as the default values or any input to the private\_link\_private\_dns\_zones parameter e.g. privatelink.api.azureml.ms or privatelink.{regionCode}.backup.windowsazure.com or azure\_ml.
 
 Type: `set(string)`
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Default: `null`
 
 ### <a name="input_private_link_excluded_zones"></a> [private\_link\_excluded\_zones](#input\_private\_link\_excluded\_zones)
 
-Description: A list of Private Link Private DNS Zones to exclude. Either DNS zone names or the `private_link_private_dns_zones` map key name (e.g. 'azure\_ml') must match what is provided as the default values or any input to the private\_link\_private\_dns\_zones parameter e.g. privatelink.api.azureml.ms or privatelink.{regionCode}.backup.windowsazure.com or azure\_ml.
+Description: A set of Private Link Private DNS Zones to exclude. Either DNS zone names or the `private_link_private_dns_zones` map key name (e.g. 'azure\_ml') must match what is provided as the default values or any input to the private\_link\_private\_dns\_zones parameter e.g. privatelink.api.azureml.ms or privatelink.{regionCode}.backup.windowsazure.com or azure\_ml.
 
 Type: `set(string)`
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ object({
 
 Default: `null`
 
+### <a name="input_private_link_excluded_zones"></a> [private\_link\_excluded\_zones](#input\_private\_link\_excluded\_zones)
+
+Description: A list of Private Link Private DNS Zones to exclude. The DNS zone names must match what is provided as the default values or any input to the private\_link\_private\_dns\_zones parameter e.g. privatelink.api.azureml.ms or privatelink.{regionCode}.backup.windowsazure.com or privatelink.{regionName}.azmk8s.io.
+
+Type: `set(string)`
+
+Default: `[]`
+
 ### <a name="input_private_link_private_dns_zones"></a> [private\_link\_private\_dns\_zones](#input\_private\_link\_private\_dns\_zones)
 
 Description: A set of Private Link Private DNS Zones to create. Each element must be a valid DNS zone name.
@@ -398,7 +406,7 @@ Default:
 
 Description: A set of Private Link Private DNS Zones to create in addition to the zones supplied in `private_link_private_dns_zones`. Each element must be a valid DNS zone name.
 
-The purpose of this variable is to allow the use of our default zones and just add any additioanl zones without having to redefine the entire set of default zones.
+The purpose of this variable is to allow the use of our default zones and just add any additional zones without having to redefine the entire set of default zones.
 
 - `zone_name` - The name of the Private Link Private DNS Zone to create. This can include placeholders for the region code and region name, which will be replaced with the appropriate values based on the `location` variable.
 - `custom_iterator` - (Optional) An object that defines a custom iterator for the Private Link Private DNS Zone. This is used to create multiple Private Link Private DNS Zones with the same base name but different replacements. The object must contain:

--- a/examples/exclusions/README.md
+++ b/examples/exclusions/README.md
@@ -1,0 +1,145 @@
+<!-- BEGIN_TF_DOCS -->
+# Exclusions example
+
+This deploys the module demonstrating how to exclude zones from the default list.
+
+It will deploy all known Azure Private DNS Zones for Azure Services that support Private Link in a new Resource Group that it will create with the name provided.
+
+```hcl
+terraform {
+  required_version = "~> 1.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0, < 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+module "regions" {
+  source  = "Azure/regions/azurerm"
+  version = "~> 0.3"
+}
+
+resource "random_integer" "region_index" {
+  max = length(module.regions.regions) - 1
+  min = 0
+}
+
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.3"
+}
+
+module "test" {
+  source = "../../"
+
+  # source             = "Azure/avm-ptn-network-private-link-private-dns-zones/azurerm"
+  location                    = module.regions.regions[random_integer.region_index.result].name
+  resource_group_name         = module.naming.resource_group.name_unique
+  enable_telemetry            = var.enable_telemetry
+  private_link_excluded_zones = ["azure_ml_notebooks", "privatelink.{regionName}.azurecontainerapps.io", "privatelink.tip1.powerquery.microsoft.com"]
+  private_link_private_dns_zones = {
+    azure_container_apps = {
+      zone_name = "privatelink.{regionName}.azurecontainerapps.io"
+    }
+    azure_ml = {
+      zone_name = "privatelink.api.azureml.ms"
+    }
+    azure_ml_notebooks = {
+      zone_name = "privatelink.notebooks.azure.net"
+    }
+
+    azure_power_bi_dedicated = {
+      zone_name = "privatelink.pbidedicated.windows.net"
+    }
+    azure_power_bi_power_query = {
+      zone_name = "privatelink.tip1.powerquery.microsoft.com"
+    }
+
+  }
+}
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.0, < 5.0)
+
+- <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
+
+## Resources
+
+The following resources are used by this module:
+
+- [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
+- [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+No required inputs.
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_enable_telemetry"></a> [enable\_telemetry](#input\_enable\_telemetry)
+
+Description: This variable controls whether or not telemetry is enabled for the module.  
+For more information see <https://aka.ms/avm/telemetryinfo>.  
+If it is set to false, then no telemetry will be collected.
+
+Type: `bool`
+
+Default: `true`
+
+## Outputs
+
+No outputs.
+
+## Modules
+
+The following Modules are called:
+
+### <a name="module_naming"></a> [naming](#module\_naming)
+
+Source: Azure/naming/azurerm
+
+Version: ~> 0.3
+
+### <a name="module_regions"></a> [regions](#module\_regions)
+
+Source: Azure/regions/azurerm
+
+Version: ~> 0.3
+
+### <a name="module_test"></a> [test](#module\_test)
+
+Source: ../../
+
+Version:
+
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+<!-- END_TF_DOCS -->

--- a/examples/exclusions/README.md
+++ b/examples/exclusions/README.md
@@ -3,7 +3,7 @@
 
 This deploys the module demonstrating how to exclude zones from the default list.
 
-It will deploy all known Azure Private DNS Zones for Azure Services that support Private Link in a new Resource Group that it will create with the name provided.
+It will deploy a selection of Azure Private DNS Zones for Azure Services that support Private Link in a new Resource Group that it will create with the name provided.
 
 ```hcl
 terraform {

--- a/examples/exclusions/_footer.md
+++ b/examples/exclusions/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/exclusions/_header.md
+++ b/examples/exclusions/_header.md
@@ -2,4 +2,4 @@
 
 This deploys the module demonstrating how to exclude zones from the default list.
 
-It will deploy all known Azure Private DNS Zones for Azure Services that support Private Link in a new Resource Group that it will create with the name provided.
+It will deploy a selection of Azure Private DNS Zones for Azure Services that support Private Link in a new Resource Group that it will create with the name provided.

--- a/examples/exclusions/_header.md
+++ b/examples/exclusions/_header.md
@@ -1,0 +1,5 @@
+# Exclusions example
+
+This deploys the module demonstrating how to exclude zones from the default list.
+
+It will deploy all known Azure Private DNS Zones for Azure Services that support Private Link in a new Resource Group that it will create with the name provided.

--- a/examples/exclusions/main.tf
+++ b/examples/exclusions/main.tf
@@ -1,0 +1,67 @@
+terraform {
+  required_version = "~> 1.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0, < 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+module "regions" {
+  source  = "Azure/regions/azurerm"
+  version = "~> 0.3"
+}
+
+resource "random_integer" "region_index" {
+  max = length(module.regions.regions) - 1
+  min = 0
+}
+
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.3"
+}
+
+module "test" {
+  source = "../../"
+
+  # source             = "Azure/avm-ptn-network-private-link-private-dns-zones/azurerm"
+  location                    = module.regions.regions[random_integer.region_index.result].name
+  resource_group_name         = module.naming.resource_group.name_unique
+  enable_telemetry            = var.enable_telemetry
+  private_link_excluded_zones = ["azure_ml_notebooks", "privatelink.{regionName}.azurecontainerapps.io", "privatelink.tip1.powerquery.microsoft.com"]
+  private_link_private_dns_zones = {
+    azure_container_apps = {
+      zone_name = "privatelink.{regionName}.azurecontainerapps.io"
+    }
+    azure_ml = {
+      zone_name = "privatelink.api.azureml.ms"
+    }
+    azure_ml_notebooks = {
+      zone_name = "privatelink.notebooks.azure.net"
+    }
+
+    azure_power_bi_dedicated = {
+      zone_name = "privatelink.pbidedicated.windows.net"
+    }
+    azure_power_bi_power_query = {
+      zone_name = "privatelink.tip1.powerquery.microsoft.com"
+    }
+
+  }
+}

--- a/examples/exclusions/variables.tf
+++ b/examples/exclusions/variables.tf
@@ -1,0 +1,9 @@
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see <https://aka.ms/avm/telemetryinfo>.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}

--- a/locals.tf
+++ b/locals.tf
@@ -5,12 +5,21 @@ locals {
 
 locals {
   merged_private_link_private_dns_zones = merge(var.private_link_private_dns_zones, var.private_link_private_dns_zones_additional)
-  private_link_private_dns_zones_replaced_regionCode_map = { for k, v in local.private_link_private_dns_zones_replaced_regionName_map : k => {
-    zone_name = replace(v.zone_name, "{regionCode}", local.location_geo_code)
-  } }
-  private_link_private_dns_zones_replaced_regionName_map = { for k, v in local.merged_private_link_private_dns_zones : k => {
-    zone_name = replace(v.zone_name, "{regionName}", local.location_name)
-  } }
+
+  filtered_private_link_private_dns_zones = {
+    for k, v in local.merged_private_link_private_dns_zones : k => v if !(contains(var.private_link_excluded_zones, v.zone_name))
+  }
+
+  private_link_private_dns_zones_replaced_regionName_map = {
+    for k, v in local.filtered_private_link_private_dns_zones : k => {
+      zone_name = replace(v.zone_name, "{regionName}", local.location_name)
+    }
+  }
+  private_link_private_dns_zones_replaced_regionCode_map = {
+    for k, v in local.private_link_private_dns_zones_replaced_regionName_map : k => {
+      zone_name = replace(v.zone_name, "{regionCode}", local.location_geo_code)
+    }
+  }
   virtual_network_link_name_templates = { for key, value in var.virtual_network_resource_ids_to_link_to : key => value.virtual_network_link_name_template_override == null ? var.virtual_network_link_name_template : value.virtual_network_link_name_template_override }
 }
 
@@ -18,10 +27,10 @@ locals {
   combined_private_link_private_dns_zones_replaced_with_vnets_to_link = {
     for item in flatten([
       for zone_key, zone_value in local.private_link_private_dns_zones_replaced_regionCode_map : [
-        for custom_iterator_key, custom_iterator_value in try(local.merged_private_link_private_dns_zones[zone_key].custom_iterator.replacement_values, { no_custom_iterator = null }) :
+        for custom_iterator_key, custom_iterator_value in try(local.filtered_private_link_private_dns_zones[zone_key].custom_iterator.replacement_values, { no_custom_iterator = null }) :
         {
           zone_key  = custom_iterator_value == null ? zone_key : "${zone_key}_${custom_iterator_key}"
-          zone_name = custom_iterator_value == null ? zone_value.zone_name : replace(zone_value.zone_name, "{${local.merged_private_link_private_dns_zones[zone_key].custom_iterator.replacement_placeholder}}", custom_iterator_key)
+          zone_name = custom_iterator_value == null ? zone_value.zone_name : replace(zone_value.zone_name, "{${local.filtered_private_link_private_dns_zones[zone_key].custom_iterator.replacement_placeholder}}", custom_iterator_key)
           vnets = {
             for vnet_key, vnet_value in var.virtual_network_resource_ids_to_link_to : vnet_key => {
               vnetid           = vnet_value.vnet_resource_id

--- a/locals.tf
+++ b/locals.tf
@@ -4,20 +4,18 @@ locals {
 }
 
 locals {
-  merged_private_link_private_dns_zones = merge(var.private_link_private_dns_zones, var.private_link_private_dns_zones_additional)
-
   filtered_private_link_private_dns_zones = {
-    for k, v in local.merged_private_link_private_dns_zones : k => v if !(contains(var.private_link_excluded_zones, v.zone_name))
+    for k, v in local.merged_private_link_private_dns_zones : k => v if !(contains(var.private_link_excluded_zones, v.zone_name) || contains(var.private_link_excluded_zones, k))
   }
-
-  private_link_private_dns_zones_replaced_regionName_map = {
-    for k, v in local.filtered_private_link_private_dns_zones : k => {
-      zone_name = replace(v.zone_name, "{regionName}", local.location_name)
-    }
-  }
+  merged_private_link_private_dns_zones = merge(var.private_link_private_dns_zones, var.private_link_private_dns_zones_additional)
   private_link_private_dns_zones_replaced_regionCode_map = {
     for k, v in local.private_link_private_dns_zones_replaced_regionName_map : k => {
       zone_name = replace(v.zone_name, "{regionCode}", local.location_geo_code)
+    }
+  }
+  private_link_private_dns_zones_replaced_regionName_map = {
+    for k, v in local.filtered_private_link_private_dns_zones : k => {
+      zone_name = replace(v.zone_name, "{regionName}", local.location_name)
     }
   }
   virtual_network_link_name_templates = { for key, value in var.virtual_network_resource_ids_to_link_to : key => value.virtual_network_link_name_template_override == null ? var.virtual_network_link_name_template : value.virtual_network_link_name_template_override }

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ DESCRIPTION
 variable "private_link_excluded_zones" {
   type        = set(string)
   default     = []
-  description = "A list of Private Link Private DNS Zones to exclude. The DNS zone names must match what is provided as the default values or any input to the private_link_private_dns_zones parameter e.g. privatelink.api.azureml.ms or privatelink.{regionCode}.backup.windowsazure.com or privatelink.{regionName}.azmk8s.io."
+  description = "A list of Private Link Private DNS Zones to exclude. Either DNS zone names or the `private_link_private_dns_zones` map key name (e.g. 'azure_ml') must match what is provided as the default values or any input to the private_link_private_dns_zones parameter e.g. privatelink.api.azureml.ms or privatelink.{regionCode}.backup.windowsazure.com or azure_ml."
 }
 
 variable "private_link_private_dns_zones" {

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ DESCRIPTION
 variable "private_link_excluded_zones" {
   type        = set(string)
   default     = []
-  description = "A list of Private Link Private DNS Zones to exclude. Either DNS zone names or the `private_link_private_dns_zones` map key name (e.g. 'azure_ml') must match what is provided as the default values or any input to the private_link_private_dns_zones parameter e.g. privatelink.api.azureml.ms or privatelink.{regionCode}.backup.windowsazure.com or azure_ml."
+  description = "A set of Private Link Private DNS Zones to exclude. Either DNS zone names or the `private_link_private_dns_zones` map key name (e.g. 'azure_ml') must match what is provided as the default values or any input to the private_link_private_dns_zones parameter e.g. privatelink.api.azureml.ms or privatelink.{regionCode}.backup.windowsazure.com or azure_ml."
 }
 
 variable "private_link_private_dns_zones" {

--- a/variables.tf
+++ b/variables.tf
@@ -343,7 +343,7 @@ variable "private_link_private_dns_zones_additional" {
   description = <<DESCRIPTION
 A set of Private Link Private DNS Zones to create in addition to the zones supplied in `private_link_private_dns_zones`. Each element must be a valid DNS zone name.
 
-The purpose of this variable is to allow the use of our default zones and just add any additioanl zones without having to redefine the entire set of default zones.
+The purpose of this variable is to allow the use of our default zones and just add any additional zones without having to redefine the entire set of default zones.
 
 - `zone_name` - The name of the Private Link Private DNS Zone to create. This can include placeholders for the region code and region name, which will be replaced with the appropriate values based on the `location` variable.
 - `custom_iterator` - (Optional) An object that defines a custom iterator for the Private Link Private DNS Zone. This is used to create multiple Private Link Private DNS Zones with the same base name but different replacements. The object must contain:
@@ -351,6 +351,12 @@ The purpose of this variable is to allow the use of our default zones and just a
   - `replacement_values` - A map of values to use for the custom iterator, where the value is the value to replace in the `zone_name`.
 DESCRIPTION
   nullable    = false
+}
+
+variable "private_link_excluded_zones" {
+  default = ["privatelink.pbidedicated.windows.net", "privatelink.analysis.windows.net", "privatelink.tip1.powerquery.microsoft.com"]
+  type = list(string)
+  description = "A list of Private Link Private DNS Zones to exclude. The DNS zone names must match what is provided as the default values or any input to the private_link_private_dns_zones parameter e.g. privatelink.api.azureml.ms or privatelink.{regionCode}.backup.windowsazure.com or privatelink.{regionName}.azmk8s.io."
 }
 
 variable "resource_group_creation_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,12 @@ DESCRIPTION
   }
 }
 
+variable "private_link_excluded_zones" {
+  type        = set(string)
+  default     = []
+  description = "A list of Private Link Private DNS Zones to exclude. The DNS zone names must match what is provided as the default values or any input to the private_link_private_dns_zones parameter e.g. privatelink.api.azureml.ms or privatelink.{regionCode}.backup.windowsazure.com or privatelink.{regionName}.azmk8s.io."
+}
+
 variable "private_link_private_dns_zones" {
   type = map(object({
     zone_name = optional(string, null)
@@ -351,12 +357,6 @@ The purpose of this variable is to allow the use of our default zones and just a
   - `replacement_values` - A map of values to use for the custom iterator, where the value is the value to replace in the `zone_name`.
 DESCRIPTION
   nullable    = false
-}
-
-variable "private_link_excluded_zones" {
-  default = ["privatelink.pbidedicated.windows.net", "privatelink.analysis.windows.net", "privatelink.tip1.powerquery.microsoft.com"]
-  type = list(string)
-  description = "A list of Private Link Private DNS Zones to exclude. The DNS zone names must match what is provided as the default values or any input to the private_link_private_dns_zones parameter e.g. privatelink.api.azureml.ms or privatelink.{regionCode}.backup.windowsazure.com or privatelink.{regionName}.azmk8s.io."
 }
 
 variable "resource_group_creation_enabled" {


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Closes https://github.com/Azure/terraform-azurerm-avm-ptn-network-private-link-private-dns-zones/pull/83

Tested locally by adding exclusions and running `terraform plan`



## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ x Azure Verified Module updates:
  - [] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
