### PR TITLE
feat: filter for secondary region

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,30 @@ map(object({
 
 Default: `{}`
 
+### <a name="input_private_link_private_dns_zones_filter"></a> [private\_link\_private\_dns\_zones\_filter](#input\_private\_link\_private\_dns\_zones\_filter)
+
+Description: This variable controls whether or not the Private Link Private DNS Zones should be filtered based on the region name and region code. If enabled, the `filter` will be used to filter the Private Link Private DNS Zones based on the region name and region code.
+- `enabled` - (Optional) Whether to enable filtering of the Private Link Private DNS Zones. Defaults to `false`.
+- `filter` - (Optional) The regular expression filter to apply to the Private Link Private DNS Zones. The default value is `{regionName}|{regionCode}`, which will filter for regional Private Link Private DNS Zones often needed for secondary regions. You can specify a custom filter to match your requirements.
+
+Type:
+
+```hcl
+object({
+    enabled = optional(bool, false)
+    filter  = optional(string, "{regionName}|{regionCode}")
+  })
+```
+
+Default:
+
+```json
+{
+  "enabled": true,
+  "filter": null
+}
+```
+
 ### <a name="input_resource_group_creation_enabled"></a> [resource\_group\_creation\_enabled](#input\_resource\_group\_creation\_enabled)
 
 Description: This variable controls whether or not the resource group should be created. If set to false, the resource group must be created elsewhere and the resource group name must be provided to the module. If set to true, the resource group will be created by the module using the name provided in `resource_group_name`.

--- a/README.md
+++ b/README.md
@@ -427,29 +427,22 @@ map(object({
 
 Default: `{}`
 
-### <a name="input_private_link_private_dns_zones_filter"></a> [private\_link\_private\_dns\_zones\_filter](#input\_private\_link\_private\_dns\_zones\_filter)
+### <a name="input_private_link_private_dns_zones_regex_filter"></a> [private\_link\_private\_dns\_zones\_regex\_filter](#input\_private\_link\_private\_dns\_zones\_regex\_filter)
 
-Description: This variable controls whether or not the Private Link Private DNS Zones should be filtered based on the region name and region code. If enabled, the `filter` will be used to filter the Private Link Private DNS Zones based on the region name and region code.
+Description: This variable controls whether or not the Private Link Private DNS Zones should be filtered based on the zone name. If enabled, the `regex_filter` will be used to filter the Private Link Private DNS Zones based on the zone name.
 - `enabled` - (Optional) Whether to enable filtering of the Private Link Private DNS Zones. Defaults to `false`.
-- `filter` - (Optional) The regular expression filter to apply to the Private Link Private DNS Zones. The default value is `{regionName}|{regionCode}`, which will filter for regional Private Link Private DNS Zones often needed for secondary regions. You can specify a custom filter to match your requirements.
+- `regex_filter` - (Optional) The regular expression filter to apply to the Private Link Private DNS Zones. The default value is `{regionName}|{regionCode}`, which will filter for regional Private Link Private DNS Zones often needed for secondary regions. You can specify a custom filter to match your requirements.
 
 Type:
 
 ```hcl
 object({
-    enabled = optional(bool, false)
-    filter  = optional(string, "{regionName}|{regionCode}")
+    enabled      = optional(bool, false)
+    regex_filter = optional(string, "{regionName}|{regionCode}")
   })
 ```
 
-Default:
-
-```json
-{
-  "enabled": true,
-  "filter": null
-}
-```
+Default: `{}`
 
 ### <a name="input_resource_group_creation_enabled"></a> [resource\_group\_creation\_enabled](#input\_resource\_group\_creation\_enabled)
 

--- a/examples/secondary-region/README.md
+++ b/examples/secondary-region/README.md
@@ -13,10 +13,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 4.0, < 5.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.5"
-    }
   }
 }
 
@@ -60,8 +56,6 @@ The following requirements are needed by this module:
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.0, < 5.0)
-
-- <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
 
 ## Resources
 

--- a/examples/secondary-region/README.md
+++ b/examples/secondary-region/README.md
@@ -41,7 +41,7 @@ module "test" {
   location            = "uksouth"
   resource_group_name = azurerm_resource_group.this.name
   enable_telemetry    = var.enable_telemetry
-  private_link_private_dns_zones_filter = {
+  private_link_private_dns_zones_regex_filter = {
     enabled = true
   }
   resource_group_creation_enabled = false

--- a/examples/secondary-region/README.md
+++ b/examples/secondary-region/README.md
@@ -1,0 +1,115 @@
+<!-- BEGIN_TF_DOCS -->
+# Secondary region filter example
+
+This deploys the module demonstrating how to only include regional DNS zones often required for a secondary landing zone region.
+
+It will deploy a selection of Azure Private DNS Zones for Azure Services that support Private Link in a new Resource Group that it will create with the name provided.
+
+```hcl
+terraform {
+  required_version = "~> 1.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0, < 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.3"
+}
+
+resource "azurerm_resource_group" "this" {
+  location = "uksouth"
+  name     = module.naming.resource_group.name_unique
+}
+
+module "test" {
+  source = "../../"
+
+  # source             = "Azure/avm-ptn-network-private-link-private-dns-zones/azurerm"
+  location            = "uksouth"
+  resource_group_name = azurerm_resource_group.this.name
+  enable_telemetry    = var.enable_telemetry
+  private_link_private_dns_zones_filter = {
+    enabled = true
+  }
+  resource_group_creation_enabled = false
+}
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.0, < 5.0)
+
+- <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+No required inputs.
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_enable_telemetry"></a> [enable\_telemetry](#input\_enable\_telemetry)
+
+Description: This variable controls whether or not telemetry is enabled for the module.  
+For more information see <https://aka.ms/avm/telemetryinfo>.  
+If it is set to false, then no telemetry will be collected.
+
+Type: `bool`
+
+Default: `true`
+
+## Outputs
+
+No outputs.
+
+## Modules
+
+The following Modules are called:
+
+### <a name="module_naming"></a> [naming](#module\_naming)
+
+Source: Azure/naming/azurerm
+
+Version: ~> 0.3
+
+### <a name="module_test"></a> [test](#module\_test)
+
+Source: ../../
+
+Version:
+
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+<!-- END_TF_DOCS -->

--- a/examples/secondary-region/_footer.md
+++ b/examples/secondary-region/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/secondary-region/_header.md
+++ b/examples/secondary-region/_header.md
@@ -1,0 +1,5 @@
+# Secondary region filter example
+
+This deploys the module demonstrating how to only include regional DNS zones often required for a secondary landing zone region.
+
+It will deploy a selection of Azure Private DNS Zones for Azure Services that support Private Link in a new Resource Group that it will create with the name provided.

--- a/examples/secondary-region/main.tf
+++ b/examples/secondary-region/main.tf
@@ -5,10 +5,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 4.0, < 5.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.5"
-    }
   }
 }
 

--- a/examples/secondary-region/main.tf
+++ b/examples/secondary-region/main.tf
@@ -1,0 +1,44 @@
+terraform {
+  required_version = "~> 1.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0, < 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.3"
+}
+
+resource "azurerm_resource_group" "this" {
+  location = "uksouth"
+  name     = module.naming.resource_group.name_unique
+}
+
+module "test" {
+  source = "../../"
+
+  # source             = "Azure/avm-ptn-network-private-link-private-dns-zones/azurerm"
+  location            = "uksouth"
+  resource_group_name = azurerm_resource_group.this.name
+  enable_telemetry    = var.enable_telemetry
+  private_link_private_dns_zones_filter = {
+    enabled = true
+  }
+  resource_group_creation_enabled = false
+}

--- a/examples/secondary-region/main.tf
+++ b/examples/secondary-region/main.tf
@@ -33,7 +33,7 @@ module "test" {
   location            = "uksouth"
   resource_group_name = azurerm_resource_group.this.name
   enable_telemetry    = var.enable_telemetry
-  private_link_private_dns_zones_filter = {
+  private_link_private_dns_zones_regex_filter = {
     enabled = true
   }
   resource_group_creation_enabled = false

--- a/examples/secondary-region/variables.tf
+++ b/examples/secondary-region/variables.tf
@@ -1,0 +1,9 @@
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see <https://aka.ms/avm/telemetryinfo>.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}

--- a/locals.tf
+++ b/locals.tf
@@ -5,7 +5,7 @@ locals {
 
 locals {
   filtered_private_link_private_dns_zones = {
-    for k, v in local.merged_private_link_private_dns_zones : k => v if !(contains(var.private_link_excluded_zones, v.zone_name) || contains(var.private_link_excluded_zones, k))
+    for k, v in local.regex_filtered_private_link_private_dns_zones : k => v if !(contains(var.private_link_excluded_zones, v.zone_name) || contains(var.private_link_excluded_zones, k))
   }
   merged_private_link_private_dns_zones = merge(var.private_link_private_dns_zones, var.private_link_private_dns_zones_additional)
   private_link_private_dns_zones_replaced_regionCode_map = {
@@ -18,6 +18,9 @@ locals {
       zone_name = replace(v.zone_name, "{regionName}", local.location_name)
     }
   }
+  regex_filtered_private_link_private_dns_zones = var.private_link_private_dns_zones_filter.enabled ? {
+    for k, v in local.merged_private_link_private_dns_zones : k => v if length(regexall(var.private_link_private_dns_zones_filter.filter, v.zone_name)) > 0
+  } : local.merged_private_link_private_dns_zones
   virtual_network_link_name_templates = { for key, value in var.virtual_network_resource_ids_to_link_to : key => value.virtual_network_link_name_template_override == null ? var.virtual_network_link_name_template : value.virtual_network_link_name_template_override }
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -18,8 +18,8 @@ locals {
       zone_name = replace(v.zone_name, "{regionName}", local.location_name)
     }
   }
-  regex_filtered_private_link_private_dns_zones = var.private_link_private_dns_zones_filter.enabled ? {
-    for k, v in local.merged_private_link_private_dns_zones : k => v if length(regexall(var.private_link_private_dns_zones_filter.filter, v.zone_name)) > 0
+  regex_filtered_private_link_private_dns_zones = var.private_link_private_dns_zones_regex_filter.enabled ? {
+    for k, v in local.merged_private_link_private_dns_zones : k => v if length(regexall(var.private_link_private_dns_zones_regex_filter.regex_filter, v.zone_name)) > 0
   } : local.merged_private_link_private_dns_zones
   virtual_network_link_name_templates = { for key, value in var.virtual_network_resource_ids_to_link_to : key => value.virtual_network_link_name_template_override == null ? var.virtual_network_link_name_template : value.virtual_network_link_name_template_override }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -359,19 +359,16 @@ DESCRIPTION
   nullable    = false
 }
 
-variable "private_link_private_dns_zones_filter" {
+variable "private_link_private_dns_zones_regex_filter" {
   type = object({
-    enabled = optional(bool, false)
-    filter  = optional(string, "{regionName}|{regionCode}")
+    enabled      = optional(bool, false)
+    regex_filter = optional(string, "{regionName}|{regionCode}")
   })
-  default = {
-    enabled = true
-    filter  = null
-  }
+  default     = {}
   description = <<DESCRIPTION
-This variable controls whether or not the Private Link Private DNS Zones should be filtered based on the region name and region code. If enabled, the `filter` will be used to filter the Private Link Private DNS Zones based on the region name and region code.
+This variable controls whether or not the Private Link Private DNS Zones should be filtered based on the zone name. If enabled, the `regex_filter` will be used to filter the Private Link Private DNS Zones based on the zone name.
 - `enabled` - (Optional) Whether to enable filtering of the Private Link Private DNS Zones. Defaults to `false`.
-- `filter` - (Optional) The regular expression filter to apply to the Private Link Private DNS Zones. The default value is `{regionName}|{regionCode}`, which will filter for regional Private Link Private DNS Zones often needed for secondary regions. You can specify a custom filter to match your requirements.
+- `regex_filter` - (Optional) The regular expression filter to apply to the Private Link Private DNS Zones. The default value is `{regionName}|{regionCode}`, which will filter for regional Private Link Private DNS Zones often needed for secondary regions. You can specify a custom filter to match your requirements.
 DESCRIPTION
   nullable    = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -359,6 +359,23 @@ DESCRIPTION
   nullable    = false
 }
 
+variable "private_link_private_dns_zones_filter" {
+  type = object({
+    enabled = optional(bool, false)
+    filter  = optional(string, "{regionName}|{regionCode}")
+  })
+  default = {
+    enabled = true
+    filter  = null
+  }
+  description = <<DESCRIPTION
+This variable controls whether or not the Private Link Private DNS Zones should be filtered based on the region name and region code. If enabled, the `filter` will be used to filter the Private Link Private DNS Zones based on the region name and region code.
+- `enabled` - (Optional) Whether to enable filtering of the Private Link Private DNS Zones. Defaults to `false`.
+- `filter` - (Optional) The regular expression filter to apply to the Private Link Private DNS Zones. The default value is `{regionName}|{regionCode}`, which will filter for regional Private Link Private DNS Zones often needed for secondary regions. You can specify a custom filter to match your requirements.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "resource_group_creation_enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Add a filter to enable filtering for regional zones to ensure we can have a single source of truth for secondary regions and no longer need to supply them.

Related to: https://github.com/Azure/ALZ-PowerShell-Module/issues/357

Closes: #39 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
