### PR TITLE
feat: bump utl version for new geo codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,7 +792,7 @@ Version: 0.4.3
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.2
+Version: 0.9.3
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/avm
+++ b/avm
@@ -48,6 +48,15 @@ if [ -d "${AZURE_CONFIG_DIR}" ]; then
   AZURE_CONFIG_MOUNT="-v ${AZURE_CONFIG_DIR}:/home/runtimeuser/.azure"
 fi
 
+# Check if AVM_TMP_DIR is set, if so mount it to /tmp
+if [ -z "${AVM_TMP_DIR}" ] && [ -n "${RUNNER_TEMP}" ]; then
+  AVM_TMP_DIR="${RUNNER_TEMP}"
+fi
+
+if [ -n "${AVM_TMP_DIR}" ]; then
+  TMP_MOUNT="-v ${AVM_TMP_DIR}:/tmp"
+fi
+
 # If the host Docker socket exists, mount it into the container so the container can talk to the host docker daemon
 if [ -S /var/run/docker.sock ]; then
   DOCKER_SOCK_MOUNT="-v /var/run/docker.sock:/var/run/docker.sock"
@@ -99,6 +108,7 @@ if [ -z "${AVM_IN_CONTAINER}" ]; then
     ${AZURE_CONFIG_MOUNT:-} \
     ${DOCKER_SOCK_MOUNT:-} \
     ${SSL_CERT_MOUNTS:-} \
+    ${TMP_MOUNT:-} \
     -e ARM_CLIENT_ID \
     -e ARM_OIDC_REQUEST_TOKEN \
     -e ARM_OIDC_REQUEST_URL \

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "avm_interfaces" {
 
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.2"
+  version = "0.9.3"
 
   enable_telemetry = var.enable_telemetry
 }


### PR DESCRIPTION
This pull request updates the version of the `Azure/avm-utl-regions/azurerm` module to get the latest geo codes added in the module as part of https://github.com/Azure/terraform-azurerm-avm-utl-regions/pull/89

* Module Version Update:
  * Upgraded the `regions` module version from `0.9.2` to `0.9.3` in `main.tf`.