### PR TITLE
feat: add the ability to create role assignments for specific DNS zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,40 @@ Type: `string`
 
 Default: `"Default"`
 
+### <a name="input_virtual_network_role_assignments"></a> [virtual\_network\_role\_assignments](#input\_virtual\_network\_role\_assignments)
+
+Description: A map of maps to create role assignments on the Virtual Network.
+
+The first key is the the private link private DNS zone map key from the `private_link_private_dns_zones` or `private_link_private_dns_zones_additional` variables.  
+The second key is an arbitrary map key for the role assignment.
+
+- `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
+- `principal_id` - The ID of the principal to assign the role to.
+- `principal_type` - (Optional) The type of the principal. Possible values are `User`, `Group`, and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
+- `description` - The description of the role assignment.
+- `skip_service_principal_aad_check` - If set to true, skips the Entra ID check for the service principal in the tenant. Defaults to `false`.
+- `condition` - The condition which will be used to scope the role assignment.
+- `condition_version` - The version of the condition syntax. Valid values are '2.0'.
+
+> Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
+
+Type:
+
+```hcl
+map(map(object({
+    role_definition_id_or_name             = string
+    principal_id                           = string
+    principal_type                         = optional(string, null)
+    description                            = optional(string, null)
+    skip_service_principal_aad_check       = optional(bool, false)
+    condition                              = optional(string, null)
+    condition_version                      = optional(string, null)
+    delegated_managed_identity_resource_id = optional(string, null)
+  })))
+```
+
+Default: `{}`
+
 ## Outputs
 
 The following outputs are exported:

--- a/README.md
+++ b/README.md
@@ -496,6 +496,40 @@ object({
 
 Default: `{}`
 
+### <a name="input_private_link_private_dns_zones_role_assignments"></a> [private\_link\_private\_dns\_zones\_role\_assignments](#input\_private\_link\_private\_dns\_zones\_role\_assignments)
+
+Description: A map of maps to create role assignments on the private DNS Zone.
+
+The first key is the the private link private DNS zone map key from the `private_link_private_dns_zones` or `private_link_private_dns_zones_additional` variables.  
+The second key is an arbitrary map key for the role assignment.
+
+- `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
+- `principal_id` - The ID of the principal to assign the role to.
+- `principal_type` - (Optional) The type of the principal. Possible values are `User`, `Group`, and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
+- `description` - The description of the role assignment.
+- `skip_service_principal_aad_check` - If set to true, skips the Entra ID check for the service principal in the tenant. Defaults to `false`.
+- `condition` - The condition which will be used to scope the role assignment.
+- `condition_version` - The version of the condition syntax. Valid values are '2.0'.
+
+> Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
+
+Type:
+
+```hcl
+map(map(object({
+    role_definition_id_or_name             = string
+    principal_id                           = string
+    principal_type                         = optional(string, null)
+    description                            = optional(string, null)
+    skip_service_principal_aad_check       = optional(bool, false)
+    condition                              = optional(string, null)
+    condition_version                      = optional(string, null)
+    delegated_managed_identity_resource_id = optional(string, null)
+  })))
+```
+
+Default: `{}`
+
 ### <a name="input_resource_group_role_assignments"></a> [resource\_group\_role\_assignments](#input\_resource\_group\_role\_assignments)
 
 Description: A map of role assignments to create on the Resource Group. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
@@ -756,40 +790,6 @@ Type: `string`
 
 Default: `"Default"`
 
-### <a name="input_virtual_network_role_assignments"></a> [virtual\_network\_role\_assignments](#input\_virtual\_network\_role\_assignments)
-
-Description: A map of maps to create role assignments on the Virtual Network.
-
-The first key is the the private link private DNS zone map key from the `private_link_private_dns_zones` or `private_link_private_dns_zones_additional` variables.  
-The second key is an arbitrary map key for the role assignment.
-
-- `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
-- `principal_id` - The ID of the principal to assign the role to.
-- `principal_type` - (Optional) The type of the principal. Possible values are `User`, `Group`, and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
-- `description` - The description of the role assignment.
-- `skip_service_principal_aad_check` - If set to true, skips the Entra ID check for the service principal in the tenant. Defaults to `false`.
-- `condition` - The condition which will be used to scope the role assignment.
-- `condition_version` - The version of the condition syntax. Valid values are '2.0'.
-
-> Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
-
-Type:
-
-```hcl
-map(map(object({
-    role_definition_id_or_name             = string
-    principal_id                           = string
-    principal_type                         = optional(string, null)
-    description                            = optional(string, null)
-    skip_service_principal_aad_check       = optional(bool, false)
-    condition                              = optional(string, null)
-    condition_version                      = optional(string, null)
-    delegated_managed_identity_resource_id = optional(string, null)
-  })))
-```
-
-Default: `{}`
-
 ## Outputs
 
 The following outputs are exported:
@@ -820,7 +820,7 @@ Version: 0.5.0
 
 Source: Azure/avm-res-network-privatednszone/azurerm
 
-Version: 0.4.3
+Version: 0.5.0
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 

--- a/avm
+++ b/avm
@@ -96,6 +96,19 @@ if [ -n "${AVM_PORCH_BASE_URL}" ]; then
   PORCH_BASE_URL_MAKE_ADD="PORCH_BASE_URL=${AVM_PORCH_BASE_URL}"
 fi
 
+# Get the repo specific environment variables from avm.config if it exists
+LOCAL_ENVIRONMENT_VARIABLES=""
+if [ -f "avm.config.json" ]; then
+  declare -A variables
+  eval "$(cat "avm.config.json" | jq -r 'to_entries[] | @sh "variables[\(.key|tostring)]=\(.value|tostring)"')"
+
+  for key in "${!variables[@]}"; do
+    export "$key"="${variables[$key]}"
+    LOCAL_ENVIRONMENT_VARIABLES="${LOCAL_ENVIRONMENT_VARIABLES}-e $key "
+    echo "Set environment variable: $key"="${variables[$key]}"
+  done
+fi
+
 # Check if we are running in a container
 # If we are then just run make directly
 if [ -z "${AVM_IN_CONTAINER}" ]; then
@@ -120,11 +133,13 @@ if [ -z "${AVM_IN_CONTAINER}" ]; then
     -e NO_COLOR \
     -e PORCH_LOG_LEVEL \
     -e TF_IN_AUTOMATION=1 \
+    ${LOCAL_ENVIRONMENT_VARIABLES} \
     --env-file <(env | grep '^TF_VAR_') \
     --env-file <(env | grep '^AVM_') \
     "${CONTAINER_IMAGE}" \
     make \
     TUI="${TUI}" \
+    AVM_PORCH_STDOUT="${AVM_PORCH_STDOUT}" \
     AVM_MAKEFILE_REF="${AVM_MAKEFILE_REF}" \
     "${PORCH_BASE_URL_MAKE_ADD}" \
     AVM_PORCH_REF="${AVM_PORCH_REF}" \

--- a/avm.ps1
+++ b/avm.ps1
@@ -130,6 +130,7 @@ if (-not $env:AVM_IN_CONTAINER) {
     "MPTF_URL",
     "NO_COLOR",
     "PORCH_LOG_LEVEL",
+    "AVM_PORCH_STDOUT",
     "TEST_TYPE",
     "TFLINT_CONFIG_URL"
   )
@@ -154,11 +155,25 @@ if (-not $env:AVM_IN_CONTAINER) {
     $dockerArgs += @("-e", "$($_.Name)=$($_.Value)")
   }
 
+  # Add local environment variables from avm.config.json
+  if (Test-Path "avm.config.json") {
+    $jsonContent = Get-Content "avm.config.json" -Raw | ConvertFrom-Json -AsHashtable
+
+    foreach ($key in $jsonContent.Keys) {
+      [System.Environment]::SetEnvironmentVariable($key, $jsonContent[$key])
+      $dockerArgs += @("-e", "$key")
+    }
+  }
+
   $dockerArgs += $CONTAINER_IMAGE
   $dockerArgs += "make"
 
   if ($TUI) {
     $dockerArgs += "TUI=$TUI"
+  }
+
+  if($env:AVM_PORCH_STDOUT) {
+    $dockerArgs += "AVM_PORCH_STDOUT=$($env:AVM_PORCH_STDOUT)"
   }
 
   $dockerArgs += "MAKEFILE_REF=$MAKEFILE_REF"

--- a/locals.tf
+++ b/locals.tf
@@ -18,6 +18,7 @@ locals {
       private_dns_zone_supports_private_link = zone_value.private_dns_zone_supports_private_link
       resolution_policy                      = zone_value.resolution_policy
       custom_iterator                        = zone_value.custom_iterator
+      role_assignments                       = lookup(var.virtual_network_role_assignments, zone_key, {})
     }
   }
   private_link_private_dns_zones_merged = merge(var.private_link_private_dns_zones, var.private_link_private_dns_zones_additional)
@@ -144,8 +145,9 @@ locals {
     for item in flatten([
       for zone_key, zone_value in local.private_link_private_dns_zones_filtered_and_processed : [
         for custom_iterator_key, custom_iterator_value in coalesce(zone_value.custom_iterator, local.default_custom_iterator).replacement_values : {
-          zone_key  = custom_iterator_value == null ? zone_key : "${zone_key}_${custom_iterator_key}"
-          zone_name = custom_iterator_value == null ? zone_value.zone_name : replace(zone_value.zone_name, "{${zone_value.custom_iterator.replacement_placeholder}}", custom_iterator_key)
+          zone_key         = custom_iterator_value == null ? zone_key : "${zone_key}_${custom_iterator_key}"
+          zone_name        = custom_iterator_value == null ? zone_value.zone_name : replace(zone_value.zone_name, "{${zone_value.custom_iterator.replacement_placeholder}}", custom_iterator_key)
+          role_assignments = custom_iterator_value == null ? zone_value.role_assignments : replace(zone_value.role_assignments, "{${zone_value.custom_iterator.replacement_placeholder}}", custom_iterator_key)
           virtual_network_links = { for vnet_link_key, vnet_link_value in local.virtual_network_link_merged_with_overrides[zone_key] : vnet_link_key => {
             virtual_network_id = vnet_link_value.virtual_network_id
             name = templatestring(vnet_link_value.name, {

--- a/locals.tf
+++ b/locals.tf
@@ -18,7 +18,7 @@ locals {
       private_dns_zone_supports_private_link = zone_value.private_dns_zone_supports_private_link
       resolution_policy                      = zone_value.resolution_policy
       custom_iterator                        = zone_value.custom_iterator
-      role_assignments                       = lookup(var.virtual_network_role_assignments, zone_key, {})
+      role_assignments                       = lookup(var.private_link_private_dns_zones_role_assignments, zone_key, {})
     }
   }
   private_link_private_dns_zones_merged = merge(var.private_link_private_dns_zones, var.private_link_private_dns_zones_additional)

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,7 @@ module "avm_res_network_privatednszone" {
   tags                  = var.tags
   timeouts              = var.timeouts
   virtual_network_links = each.value.virtual_network_links
+  role_assignments      = each.value.role_assignments
 }
 
 resource "azapi_resource" "lock" {

--- a/main.tf
+++ b/main.tf
@@ -23,10 +23,10 @@ module "avm_res_network_privatednszone" {
   domain_name           = each.value.zone_name
   parent_id             = local.resource_group_id_string
   enable_telemetry      = var.enable_telemetry
+  role_assignments      = each.value.role_assignments
   tags                  = var.tags
   timeouts              = var.timeouts
   virtual_network_links = each.value.virtual_network_links
-  role_assignments      = each.value.role_assignments
 }
 
 resource "azapi_resource" "lock" {

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ module "regions" {
 
 module "avm_res_network_privatednszone" {
   source   = "Azure/avm-res-network-privatednszone/azurerm"
-  version  = "0.4.3"
+  version  = "0.5.0"
   for_each = local.private_link_private_dns_zones_final
 
   domain_name           = each.value.zone_name

--- a/variables.tf
+++ b/variables.tf
@@ -650,7 +650,6 @@ DESCRIPTION
   }
 }
 
-
 variable "virtual_network_role_assignments" {
   type = map(map(object({
     role_definition_id_or_name             = string

--- a/variables.tf
+++ b/variables.tf
@@ -649,3 +649,35 @@ DESCRIPTION
     error_message = "The virtual_network_link_resolution_policy_default must be one of: 'Default', or 'NxDomainRedirect'."
   }
 }
+
+
+variable "virtual_network_role_assignments" {
+  type = map(map(object({
+    role_definition_id_or_name             = string
+    principal_id                           = string
+    principal_type                         = optional(string, null)
+    description                            = optional(string, null)
+    skip_service_principal_aad_check       = optional(bool, false)
+    condition                              = optional(string, null)
+    condition_version                      = optional(string, null)
+    delegated_managed_identity_resource_id = optional(string, null)
+  })))
+  default     = {}
+  description = <<DESCRIPTION
+A map of maps to create role assignments on the Virtual Network.
+
+The first key is the the private link private DNS zone map key from the `private_link_private_dns_zones` or `private_link_private_dns_zones_additional` variables.
+The second key is an arbitrary map key for the role assignment.
+
+- `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
+- `principal_id` - The ID of the principal to assign the role to.
+- `principal_type` - (Optional) The type of the principal. Possible values are `User`, `Group`, and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
+- `description` - The description of the role assignment.
+- `skip_service_principal_aad_check` - If set to true, skips the Entra ID check for the service principal in the tenant. Defaults to `false`.
+- `condition` - The condition which will be used to scope the role assignment.
+- `condition_version` - The version of the condition syntax. Valid values are '2.0'.
+
+> Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
+DESCRIPTION
+  nullable    = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -402,6 +402,37 @@ DESCRIPTION
   nullable    = false
 }
 
+variable "private_link_private_dns_zones_role_assignments" {
+  type = map(map(object({
+    role_definition_id_or_name             = string
+    principal_id                           = string
+    principal_type                         = optional(string, null)
+    description                            = optional(string, null)
+    skip_service_principal_aad_check       = optional(bool, false)
+    condition                              = optional(string, null)
+    condition_version                      = optional(string, null)
+    delegated_managed_identity_resource_id = optional(string, null)
+  })))
+  default     = {}
+  description = <<DESCRIPTION
+A map of maps to create role assignments on the private DNS Zone.
+
+The first key is the the private link private DNS zone map key from the `private_link_private_dns_zones` or `private_link_private_dns_zones_additional` variables.
+The second key is an arbitrary map key for the role assignment.
+
+- `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
+- `principal_id` - The ID of the principal to assign the role to.
+- `principal_type` - (Optional) The type of the principal. Possible values are `User`, `Group`, and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
+- `description` - The description of the role assignment.
+- `skip_service_principal_aad_check` - If set to true, skips the Entra ID check for the service principal in the tenant. Defaults to `false`.
+- `condition` - The condition which will be used to scope the role assignment.
+- `condition_version` - The version of the condition syntax. Valid values are '2.0'.
+
+> Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "resource_group_role_assignments" {
   type = map(object({
     role_definition_id_or_name             = string
@@ -648,35 +679,4 @@ DESCRIPTION
     condition     = contains(["Default", "NxDomainRedirect"], var.virtual_network_link_resolution_policy_default)
     error_message = "The virtual_network_link_resolution_policy_default must be one of: 'Default', or 'NxDomainRedirect'."
   }
-}
-
-variable "virtual_network_role_assignments" {
-  type = map(map(object({
-    role_definition_id_or_name             = string
-    principal_id                           = string
-    principal_type                         = optional(string, null)
-    description                            = optional(string, null)
-    skip_service_principal_aad_check       = optional(bool, false)
-    condition                              = optional(string, null)
-    condition_version                      = optional(string, null)
-    delegated_managed_identity_resource_id = optional(string, null)
-  })))
-  default     = {}
-  description = <<DESCRIPTION
-A map of maps to create role assignments on the Virtual Network.
-
-The first key is the the private link private DNS zone map key from the `private_link_private_dns_zones` or `private_link_private_dns_zones_additional` variables.
-The second key is an arbitrary map key for the role assignment.
-
-- `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
-- `principal_id` - The ID of the principal to assign the role to.
-- `principal_type` - (Optional) The type of the principal. Possible values are `User`, `Group`, and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
-- `description` - The description of the role assignment.
-- `skip_service_principal_aad_check` - If set to true, skips the Entra ID check for the service principal in the tenant. Defaults to `false`.
-- `condition` - The condition which will be used to scope the role assignment.
-- `condition_version` - The version of the condition syntax. Valid values are '2.0'.
-
-> Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
-DESCRIPTION
-  nullable    = false
 }


### PR DESCRIPTION
## Description

Allows the ability to set role assignments on a per-zone basis by introducing the new variable `private_link_private_dns_zones_role_assignments`. Uses a similar structure to `virtual_network_link_by_zone_and_virtual_network` by using a map of maps, with the first key being `zone_key` with the inner map being the role assignments that are passed to the matching resource module. 

Closes #128 


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [X] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
