### PR TITLE
fix: update Power BI Power Query default DNS zone from tip1 to prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Default:
     "zone_name": "privatelink.pbidedicated.windows.net"
   },
   "azure_power_bi_power_query": {
-    "zone_name": "privatelink.tip1.powerquery.microsoft.com"
+    "zone_name": "privatelink.prod.powerquery.microsoft.com"
   },
   "azure_power_bi_tenant_analysis": {
     "zone_name": "privatelink.analysis.windows.net"

--- a/examples/exclusions/README.md
+++ b/examples/exclusions/README.md
@@ -69,7 +69,7 @@ module "test" {
   private_link_excluded_zones = [
     "azure_ml_notebooks",
     "privatelink.{regionName}.azurecontainerapps.io",
-    "privatelink.tip1.powerquery.microsoft.com"
+    "privatelink.prod.powerquery.microsoft.com"
   ]
   private_link_private_dns_zones = {
     azure_container_apps = {
@@ -86,7 +86,7 @@ module "test" {
       zone_name = "privatelink.pbidedicated.windows.net"
     }
     azure_power_bi_power_query = {
-      zone_name = "privatelink.tip1.powerquery.microsoft.com"
+      zone_name = "privatelink.prod.powerquery.microsoft.com"
     }
   }
 }

--- a/examples/exclusions/main.tf
+++ b/examples/exclusions/main.tf
@@ -60,7 +60,7 @@ module "test" {
   private_link_excluded_zones = [
     "azure_ml_notebooks",
     "privatelink.{regionName}.azurecontainerapps.io",
-    "privatelink.tip1.powerquery.microsoft.com"
+    "privatelink.prod.powerquery.microsoft.com"
   ]
   private_link_private_dns_zones = {
     azure_container_apps = {
@@ -77,7 +77,7 @@ module "test" {
       zone_name = "privatelink.pbidedicated.windows.net"
     }
     azure_power_bi_power_query = {
-      zone_name = "privatelink.tip1.powerquery.microsoft.com"
+      zone_name = "privatelink.prod.powerquery.microsoft.com"
     }
   }
 }

--- a/examples/resolution_policy/README.md
+++ b/examples/resolution_policy/README.md
@@ -100,7 +100,7 @@ module "test" {
       private_dns_zone_supports_private_link = true
     }
     azure_power_bi_power_query = {
-      zone_name                              = "privatelink.tip1.powerquery.microsoft.com"
+      zone_name                              = "privatelink.prod.powerquery.microsoft.com"
       private_dns_zone_supports_private_link = true
       resolution_policy                      = "NxDomainRedirect"
     }

--- a/examples/resolution_policy/main.tf
+++ b/examples/resolution_policy/main.tf
@@ -91,7 +91,7 @@ module "test" {
       private_dns_zone_supports_private_link = true
     }
     azure_power_bi_power_query = {
-      zone_name                              = "privatelink.tip1.powerquery.microsoft.com"
+      zone_name                              = "privatelink.prod.powerquery.microsoft.com"
       private_dns_zone_supports_private_link = true
       resolution_policy                      = "NxDomainRedirect"
     }

--- a/examples/resolution_policy_with_link_overrides/README.md
+++ b/examples/resolution_policy_with_link_overrides/README.md
@@ -83,7 +83,7 @@ module "test" {
   private_link_excluded_zones = [
     "azure_ml_notebooks",
     "privatelink.{regionName}.azurecontainerapps.io",
-    "privatelink.tip1.powerquery.microsoft.com"
+    "privatelink.prod.powerquery.microsoft.com"
   ]
   virtual_network_link_default_virtual_networks = {
     "vnet1" = {

--- a/examples/resolution_policy_with_link_overrides/main.tf
+++ b/examples/resolution_policy_with_link_overrides/main.tf
@@ -74,7 +74,7 @@ module "test" {
   private_link_excluded_zones = [
     "azure_ml_notebooks",
     "privatelink.{regionName}.azurecontainerapps.io",
-    "privatelink.tip1.powerquery.microsoft.com"
+    "privatelink.prod.powerquery.microsoft.com"
   ]
   virtual_network_link_default_virtual_networks = {
     "vnet1" = {

--- a/locals.tf
+++ b/locals.tf
@@ -164,5 +164,3 @@ locals {
     ) : item.zone_key => item
   }
 }
-
-

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -1,4 +1,3 @@
-
 data "modtm_module_source" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 
@@ -20,10 +19,12 @@ resource "modtm_telemetry" "telemetry" {
     random_id       = one(random_uuid.telemetry).result
   }, { location = local.main_location })
 }
+
 locals {
   # tflint-ignore: terraform_unused_declarations
   avm_azapi_header = join(" ", [for k, v in local.avm_azapi_headers : "${k}=${v}"])
 }
+
 locals {
   avm_azapi_headers = !var.enable_telemetry ? {} : (local.fork_avm ? {
     fork_avm  = "true"
@@ -56,4 +57,3 @@ locals {
 data "azapi_client_config" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 }
-

--- a/main.tf
+++ b/main.tf
@@ -54,6 +54,3 @@ resource "azapi_resource" "role_assignments" {
   read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 }
-
-
-

--- a/variables.tf
+++ b/variables.tf
@@ -131,7 +131,7 @@ variable "private_link_private_dns_zones" {
       zone_name = "privatelink.pbidedicated.windows.net"
     }
     azure_power_bi_power_query = {
-      zone_name = "privatelink.tip1.powerquery.microsoft.com"
+      zone_name = "privatelink.prod.powerquery.microsoft.com"
     }
     azure_databricks_ui_api = {
       zone_name = "privatelink.azuredatabricks.net"


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

The default private DNS zone for azure_power_bi_power_query used the outdated 'privatelink.tip1.powerquery.microsoft.com' zone. Per current Azure documentation the recommended zone is
'privatelink.prod.powerquery.microsoft.com'.

BREAKING CHANGE: renaming the private DNS zone will destroy and recreate it for existing deployments relying on the tip1 default.

Fixes #161
Closes #161 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
